### PR TITLE
Allow more complex hosting situations (sub uri)

### DIFF
--- a/lib/omniauth/multipassword/base.rb
+++ b/lib/omniauth/multipassword/base.rb
@@ -37,7 +37,7 @@ module OmniAuth
       end
 
       def request_phase
-        OmniAuth::Form.build(:title => options.title, :url => callback_path) do |f|
+        OmniAuth::Form.build(:title => options.title, :url => callback_url) do |f|
           f.text_field     "Username", username_id
           f.password_field "Password", password_id
         end.to_response


### PR DESCRIPTION
callback_path doesn't contain bits like the sub uri at which an app is hosted (such as at '/foo'). callback_url is callback_path with bits like that added in, making the use case "just work"
