### PR TITLE
Pass GET requests to the app if not on the request path

### DIFF
--- a/lib/omniauth/multipassword/base.rb
+++ b/lib/omniauth/multipassword/base.rb
@@ -49,7 +49,11 @@ module OmniAuth
         # OmniAuth, by default, disables "GET" requests for security reasons.
         # This effectively disables showing a password form on a GET request to
         # the `request_phase`. Instead, we hook the GET requests here.
-        request_phase if on_request_path?
+        if on_request_path?
+          request_phase
+        else
+          call_app!
+        end
       end
     end
   end

--- a/spec/omniauth/multipassword/base_spec.rb
+++ b/spec/omniauth/multipassword/base_spec.rb
@@ -46,6 +46,9 @@ describe OmniAuth::MultiPassword::Base do # rubocop:disable RSpec/SpecFilePathFo
       Rack::Builder.new do
         use OmniAuth::Test::PhonySession
         use OmniAuth::Strategies::OneTest
+        map '/app-ok' do
+          run ->(env) { [200, {'Content-Type' => 'text/plain'}, ['OK']] }
+        end
         run ->(env) { [404, {'Content-Type' => 'text/plain'}, [env.key?('omniauth.auth').to_s]] }
       end.to_app
     end
@@ -65,6 +68,11 @@ describe OmniAuth::MultiPassword::Base do # rubocop:disable RSpec/SpecFilePathFo
     it 'authenticates john with correct password' do
       post '/auth/onetest/callback', username: 'john', password: 'secret'
       expect(last_response.body).to eq 'true'
+    end
+
+    it 'shows app page' do
+      get '/app-ok'
+      expect(last_response.body).to eq 'OK'
     end
   end
 end


### PR DESCRIPTION
Otherwise no GET requests can be processed by the app, but a `nil` is returned back to rack instead of a response.